### PR TITLE
Update spades step

### DIFF
--- a/lib/jgi_mg_assembly/runner/pipeline.py
+++ b/lib/jgi_mg_assembly/runner/pipeline.py
@@ -66,11 +66,11 @@ class Pipeline(object):
         If not, just returns happily.
         """
         errors = []
-        if params.get("reads_upa", None) is None:
+        if params.get("reads_upa") is None:
             errors.append("Missing a Reads object!")
-        if params.get("output_assembly_name", None) is None:
+        if params.get("output_assembly_name") is None:
             errors.append("Missing the output assembly name!")
-        if params.get("workspace_name", None) is None:
+        if params.get("workspace_name") is None:
             errors.append("Missing workspace name for the output data!")
 
         if len(errors):
@@ -96,15 +96,15 @@ class Pipeline(object):
         reporting)
         """
 
-        n_pre_filter_reads = readlength(files,
-                                        os.path.join(self.output_dir, "pre_filter_readlen.txt"))
+        pre_filter_reads_info = readlength(files,
+                                           os.path.join(self.output_dir, "pre_filter_readlen.txt"))
         rqc_output = self._run_rqcfilter(files)
-        n_filtered_reads = readlength(rqc_output["filtered_fastq_file"],
-                                      os.path.join(self.output_dir, "filtered_readlen.txt"))
+        filtered_reads_info = readlength(rqc_output["filtered_fastq_file"],
+                                         os.path.join(self.output_dir, "filtered_readlen.txt"))
         bfc_output = self._run_bfc_seqtk(rqc_output)
-        n_corrected_reads = readlength(bfc_output["unzipped"],
-                                       os.path.join(self.output_dir, "corrected_readlen.txt"))
-        spades_output = self._run_spades(bfc_output["zipped"])
+        corrected_reads_info = readlength(bfc_output["unzipped"],
+                                          os.path.join(self.output_dir, "corrected_readlen.txt"))
+        spades_output = self._run_spades(bfc_output["zipped"], corrected_reads_info)
         agp_output = self._create_agp_file(spades_output)
         stats_output = self._run_assembly_stats(agp_output["scaffolds"])
         bbmap_output = self._run_bbmap(
@@ -116,10 +116,10 @@ class Pipeline(object):
         return_dict = self._format_outputs(
             rqc_output, bfc_output, spades_output, agp_output, stats_output, bbmap_output
         )
-        return_dict["reads_counts"] = {
-            "pre_filter": n_pre_filter_reads,
-            "filtered": n_filtered_reads,
-            "corrected": n_corrected_reads
+        return_dict["reads_info"] = {
+            "pre_filter": pre_filter_reads_info,
+            "filtered": filtered_reads_info,
+            "corrected": corrected_reads_info
         }
         return return_dict
 
@@ -192,13 +192,17 @@ class Pipeline(object):
             "zipped": zipped_output
         }
 
-    def _run_spades(self, input_file):
+    def _run_spades(self, input_file, reads_info):
         """
         Runs spades, returns the generated output directory name. It's full of standard files.
         """
         spades_output_dir = os.path.join(self.output_dir, "spades", "spades3")
         mkdir(spades_output_dir)
-        spades_cmd = [SPADES, "--only-assembler", "-k", "33,55,77,99,127", "--meta", "-t", "32",
+
+        spades_kmers = [33, 55, 77, 99, 127]
+        used_kmers = [k for k in spades_kmers if k < reads_info["avg"]]
+
+        spades_cmd = [SPADES, "--only-assembler", "-k", ",".join(used_kmers), "--meta", "-t", "32",
                       "-m", "2000", "-o", spades_output_dir, "--12", input_file]
 
         print("Running SPAdes with command:")
@@ -369,5 +373,5 @@ class Pipeline(object):
             "assembly_tsv": pipeline_output["assembly_tsv"],
             "rqcfilter_log": pipeline_output["rqcfilter_log"]
         }
-        return report_util.make_report(stats_files, pipeline_output["reads_counts"],
+        return report_util.make_report(stats_files, pipeline_output["reads_info"],
                                        workspace_name, stored_objects)

--- a/lib/jgi_mg_assembly/runner/pipeline.py
+++ b/lib/jgi_mg_assembly/runner/pipeline.py
@@ -195,12 +195,16 @@ class Pipeline(object):
     def _run_spades(self, input_file, reads_info):
         """
         Runs spades, returns the generated output directory name. It's full of standard files.
+        This will use (by default) k=33,55,77,99,127.
+        However, if the max read length < any of those k, that'll be omitted.
+        For example, if your input reads are such that the longest one is 100 bases, this'll
+        omit k=127.
         """
         spades_output_dir = os.path.join(self.output_dir, "spades", "spades3")
         mkdir(spades_output_dir)
 
         spades_kmers = [33, 55, 77, 99, 127]
-        used_kmers = [k for k in spades_kmers if k < reads_info["avg"]]
+        used_kmers = [k for k in spades_kmers if k <= reads_info["max"]]
 
         spades_cmd = [SPADES, "--only-assembler", "-k", ",".join(used_kmers), "--meta", "-t", "32",
                       "-m", "2000", "-o", spades_output_dir, "--12", input_file]

--- a/lib/jgi_mg_assembly/runner/readlength.py
+++ b/lib/jgi_mg_assembly/runner/readlength.py
@@ -14,8 +14,18 @@ BBTOOLS_READLEN = "/kb/module/bbmap/readlength.sh"
 
 def readlength(input_file, output_file):
     """
-    Runs readlength.sh on input_file to generate output_file. It then skims that file for the
-    '#Reads:' line, and returns the numeric value given there.
+    Runs readlength.sh on input_file to generate output_file. It then skims that file for several
+    values and returns them as a dictionary. The keys to this are:
+    count - the number of reads
+    bases - the total number of bases
+    max - the length of the longest read
+    min - the length of the shortest read
+    avg - the average read length
+    median - the median read length
+    mode - the mode of the mean lengths
+    std_dev - the standard deviation of read lengths
+
+    This also calculates the histogram, but it left out for now. (Unless it's needed later)
 
     The path to the output file's directory is expected to exist. If not, this might cause an
     error. If the output file exists, it will be overwritten.
@@ -37,9 +47,37 @@ def readlength(input_file, output_file):
 
     if not os.path.exists(output_file):
         raise RuntimeError("The output file '{}' appears not to have been made!")
+    ret_value = dict()
     with open(output_file, "r") as read_len_file:
+        line_mapping = {
+            "#Reads:": ("count", int),
+            "#Bases:": ("bases", int),
+            "#Max:" : ("max", int),
+            "#Min:": ("min", int),
+            "#Avg:": ("avg", float),
+            "#Median:": ("median", int),
+            "#Mode:": ("mode", int),
+            "#Std_Dev:": ("std_dev", float),
+        }
         for line in read_len_file:
-            if line.startswith("#Reads:"):
-                num_reads = line.split()[-1]
-
-    return num_reads
+            chopped = line.split()
+            if chopped[0] in line_mapping:
+                key, map_fn = line_mapping[chopped[0]]
+                ret_value[key] = map_fn(chopped[1])
+            # if line.startswith("#Reads:"):
+            #     ret_value['count'] = line.split()[-1]
+            # elif line.startswith("#Bases:")
+            #     ret_value['bases'] = line.split()[-1]
+            # elif line.startswith("#Max:")
+            #     ret_value['max'] = line.split()[-1]
+            # elif line.startswith("#Min:")
+            #     ret_value['min'] = line.split()[-1]
+            # elif line.startswith("#Avg:")
+            #     ret_value['avg'] = line.split()[-1]
+            # elif line.startswith("#Median:")
+            #     ret_value['median'] = line.split()[-1]
+            # elif line.startswith("#Mode:")
+            #     ret_value['mode'] = line.split()[-1]
+            # elif line.startswith("#Std_Dev:")
+            #     ret_value['std_dev'] = line.split()[-1]
+    return ret_value

--- a/test/jgi_mg_assembly_server_test.py
+++ b/test/jgi_mg_assembly_server_test.py
@@ -8,6 +8,7 @@ from pprint import pprint  # noqa: F401
 from jgi_mg_assembly.jgi_mg_assemblyImpl import jgi_mg_assembly
 from jgi_mg_assembly.jgi_mg_assemblyServer import MethodContext
 from jgi_mg_assembly.authclient import KBaseAuth as _KBaseAuth
+from jgi_mg_assembly.runner.readlength import readlength
 
 import util
 
@@ -80,3 +81,16 @@ class jgi_mg_assemblyTest(unittest.TestCase):
                 "output_assembly_name": "MyNewAssembly",
                 "workspace_name": None
             })
+
+    def test_readlength(self):
+        # copy small fq file to scratch
+        file_path = util.file_to_scratch(os.path.join("data", "small.forward.fq"), overwrite=True)
+        reads_info = readlength(file_path, "readlen_out.txt")
+        self.assertEqual(reads_info["count"], 1250)
+        self.assertEqual(reads_info["bases"], 125000)
+        self.assertEqual(reads_info["max"], 100)
+        self.assertEqual(reads_info["min"], 100)
+        self.assertEqual(reads_info["avg"], 100.0)
+        self.assertEqual(reads_info["median"], 100)
+        self.assertEqual(reads_info["mode"], 100)
+        self.assertEqual(reads_info["std_dev"], 0.0)

--- a/test/report_util_test.py
+++ b/test/report_util_test.py
@@ -43,9 +43,15 @@ class report_util_test(unittest.TestCase):
             "rqcfilter_log": self.rqcfilter_log
         }
         reads_counts = {
-            "pre_filter": 10000,
-            "filtered": 8000,
-            "corrected": 7000
+            "pre_filter": {
+                "count": 10000
+            },
+            "filtered": {
+                "count": 8000
+            },
+            "corrected": {
+                "count": 7000
+            }
         }
         report_info = self._get_report_util().make_report(
             stats_files, reads_counts, util.get_ws_name(), []
@@ -55,9 +61,15 @@ class report_util_test(unittest.TestCase):
 
     def test_make_report_bad_inputs(self):
         reads_counts = {
-            "pre_filter": 10000,
-            "filtered": 8000,
-            "corrected": 7000
+            "pre_filter": {
+                "count": 10000
+            },
+            "filtered": {
+                "count": 8000
+            },
+            "corrected": {
+                "count": 7000
+            }
         }
         stats_files = {
             "bbmap_stats": self.bbmap_stats_file,
@@ -85,18 +97,18 @@ class report_util_test(unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             ru.make_report(stats_files, None, util.get_ws_name(), [])
-        self.assertIn("A dictionary of reads_counts is required", str(cm.exception))
+        self.assertIn("A dictionary of reads_info is required", str(cm.exception))
 
         with self.assertRaises(ValueError) as cm:
             ru.make_report(stats_files, "not a file", util.get_ws_name(), [])
-        self.assertIn("A dictionary of reads_counts is required", str(cm.exception))
+        self.assertIn("A dictionary of reads_info is required", str(cm.exception))
 
         for key in reads_counts:
             reads_copy = reads_counts.copy()
             del reads_copy[key]
             with self.assertRaises(ValueError) as cm:
                 ru.make_report(stats_files, reads_copy, util.get_ws_name(), [])
-            self.assertIn("Required reads count '{}' is not present!".format(key), str(cm.exception))
+            self.assertIn("Required reads info '{}' is not present!".format(key), str(cm.exception))
 
         with self.assertRaises(ValueError) as cm:
             ru.make_report(stats_files, reads_counts, None, [])


### PR DESCRIPTION
Includes a change to readlength to include all reads info as a dict.
Updates the report, etc., to use that properly.

Also, tells SPAdes to skip k=N where N is < the max read length for that run.
The default is to do k=33,55,77,99,127. But if our reads have a max length of 90, this will now skip 99 and 127.