### PR TITLE
SCT-1290 reporting

### DIFF
--- a/lib/jgi_mg_assembly/pipeline_steps/assemblystats.py
+++ b/lib/jgi_mg_assembly/pipeline_steps/assemblystats.py
@@ -35,12 +35,15 @@ class StatsRunner(Step):
             "2>>",
             stats_stderr
         ]
-        (exit_code, command) = super(StatsRunner, self).run(*stats_second_params)
+        (exit_code, command2) = super(StatsRunner, self).run(*stats_second_params)
         if exit_code != 0:
             raise RuntimeError("Unable to run second pass at stats to generate standard text files!")
 
         return {
             "stats_tsv": stats_output,
             "stats_txt": stats_stdout,
-            "stats_err": stats_stderr
+            "stats_err": stats_stderr,
+            "version_string": self.version_string(),
+            "command": command + " && " + command2,
+            "version_string": self.version_string()
         }

--- a/lib/jgi_mg_assembly/pipeline_steps/bbmap.py
+++ b/lib/jgi_mg_assembly/pipeline_steps/bbmap.py
@@ -40,4 +40,6 @@ class BBMapRunner(Step):
             "map_file": sam_output,
             "coverage_file": coverage_stats_output,
             "stats_file": bbmap_stats_output,
+            "command": command,
+            "version_string": self.version_string()
         }

--- a/lib/jgi_mg_assembly/pipeline_steps/bfc.py
+++ b/lib/jgi_mg_assembly/pipeline_steps/bfc.py
@@ -29,5 +29,6 @@ class BFCRunner(Step):
             raise RuntimeError("An error occurred while running BFC!")
         return {
             "command": command,
-            "corrected_reads": bfc_output_file
+            "corrected_reads": bfc_output_file,
+            "version_string": self.version_string()
         }

--- a/lib/jgi_mg_assembly/pipeline_steps/rqcfilter.py
+++ b/lib/jgi_mg_assembly/pipeline_steps/rqcfilter.py
@@ -98,6 +98,6 @@ class RQCFilterRunner(Step):
             "output_directory": outdir,
             "filtered_fastq_file": not_filtered_reads,
             "run_log": dummy_log,
-            "command": "BBTools.run_RQCFilter_local {}".format(json.dumps(self.get_parameters())),
+            "command": "BBTools.run_RQCFilter_local -- skipped. No command run.",
             "version_string": "KBase BBTools module"
         }

--- a/lib/jgi_mg_assembly/pipeline_steps/rqcfilter.py
+++ b/lib/jgi_mg_assembly/pipeline_steps/rqcfilter.py
@@ -1,8 +1,9 @@
+import os
+import json
+from time import time
 from BBTools.BBToolsClient import BBTools
 from DataFileUtil.DataFileUtilClient import DataFileUtil
 from jgi_mg_assembly.utils.util import mkdir
-import os
-from time import time
 from step import Step
 
 class RQCFilterRunner(Step):
@@ -26,27 +27,8 @@ class RQCFilterRunner(Step):
         self.skip = options.get("skip_rqcfilter")
         self.debug = options.get("debug")
 
-    def get_command(self):
-        return "rqcfilter2.sh "
-
-    def run(self, reads_file):
-        """
-        Runs RQCFilter.
-        This just calls out to BBTools.run_RQCFilter_local and returns the result.
-        reads_file: string, the path to the FASTQ file to be filtered.
-        result = dictionary with three keys -
-            output_directory = path to the output directory
-            filtered_fastq_file = as it says, gzipped
-            run_log = path to the stderr log from RQCFilter
-        """
-        if (self.skip):
-            return self.run_skip(reads_file)
-
-        print("Running RQCFilter remotely using the KBase-wrapped BBTools module...")
-        bbtools = BBTools(self.callback_url, service_ver='beta')
-        result = bbtools.run_RQCFilter_local({
-            "reads_file": reads_file
-        }, {
+    def get_parameters(self):
+        return {
             "rna": 0,
             "trimfragadapter": 1,
             "qtrim": "r",
@@ -63,8 +45,29 @@ class RQCFilterRunner(Step):
             "khist": 1,
             "removemicrobes": 1,
             "clumpify": 1
-        })
+        }
+
+    def run(self, reads_file):
+        """
+        Runs RQCFilter.
+        This just calls out to BBTools.run_RQCFilter_local and returns the result.
+        reads_file: string, the path to the FASTQ file to be filtered.
+        result = dictionary with three keys -
+            output_directory = path to the output directory
+            filtered_fastq_file = as it says, gzipped
+            run_log = path to the stderr log from RQCFilter
+        """
+        if (self.skip):
+            return self.run_skip(reads_file)
+
+        print("Running RQCFilter remotely using the KBase-wrapped BBTools module...")
+        bbtools = BBTools(self.callback_url, service_ver='beta')
+        result = bbtools.run_RQCFilter_local({ "reads_file": reads_file }, self.get_parameters())
         print("Done running RQCFilter")
+        result.update({
+            "command": "BBTools.run_RQCFilter_local {}".format(json.dumps(self.get_parameters())),
+            "version_string": "KBase BBTools module"
+        })
         return result
 
     def run_skip(self, reads_file):
@@ -94,5 +97,7 @@ class RQCFilterRunner(Step):
         return {
             "output_directory": outdir,
             "filtered_fastq_file": not_filtered_reads,
-            "run_log": dummy_log
+            "run_log": dummy_log,
+            "command": "BBTools.run_RQCFilter_local {}".format(json.dumps(self.get_parameters())),
+            "version_string": "KBase BBTools module"
         }

--- a/lib/jgi_mg_assembly/pipeline_steps/seqtk.py
+++ b/lib/jgi_mg_assembly/pipeline_steps/seqtk.py
@@ -29,5 +29,6 @@ class SeqtkRunner(Step):
 
         return {
             "command": command,
-            "cleaned_reads": zipped_output
+            "cleaned_reads": zipped_output,
+            "version_string": self.version_string()
         }

--- a/lib/jgi_mg_assembly/pipeline_steps/spades.py
+++ b/lib/jgi_mg_assembly/pipeline_steps/spades.py
@@ -61,6 +61,7 @@ class SpadesRunner(Step):
 
         return_dict = {
             "command": command,
+            "version_string": self.version_string(),
             "output_dir": spades_output_dir,
             "run_log": os.path.join(spades_output_dir, "spades.log"),
             "params_log": os.path.join(spades_output_dir, "params.txt")

--- a/lib/jgi_mg_assembly/pipeline_steps/step.py
+++ b/lib/jgi_mg_assembly/pipeline_steps/step.py
@@ -52,4 +52,4 @@ class Step(object):
         return (exit_code, ' '.join(command))
 
     def version_string(self):
-        return "{} v{}".format(self.version_name, self.version)
+        return "{} {}".format(self.version_name, self.version)

--- a/lib/jgi_mg_assembly/runner/pipeline.py
+++ b/lib/jgi_mg_assembly/runner/pipeline.py
@@ -212,19 +212,21 @@ class Pipeline(object):
             "description": "Assembled with the JGI metagenome pipeline."
         })
 
-        stats_files = {
-            "bbmap_stats": pipeline_output["bbmap"]["stats_file"],
-            "covstats": pipeline_output["bbmap"]["coverage_file"],
-            "assembly_stats": pipeline_output["stats"]["stats_txt"],
-            "assembly_tsv": pipeline_output["stats"]["stats_tsv"],
-            "rqcfilter_log": pipeline_output["rqcfilter"]["run_log"],
-            "spades_log": pipeline_output["spades"]["run_log"],
-            "spades_params": pipeline_output["spades"]["params_log"]
-        }
-        if pipeline_output["spades"].get("warnings_log"):
-            stats_files["spades_warnings"] = pipeline_output["spades"]["warnings_log"]
-        for f in ["pre_filter", "filtered", "corrected"]:
-            if f in pipeline_output["reads_info"]:
-                stats_files[f + "_reads"] = pipeline_output["reads_info"][f]["output_file"]
-        return report_util.make_report(stats_files, pipeline_output["reads_info"],
-                                       workspace_name, stored_objects)
+        return report_util.make_report(pipeline_output, workspace_name, stored_objects)
+
+        # stats_files = {
+        #     "bbmap_stats": pipeline_output["bbmap"]["stats_file"],
+        #     "covstats": pipeline_output["bbmap"]["coverage_file"],
+        #     "assembly_stats": pipeline_output["stats"]["stats_txt"],
+        #     "assembly_tsv": pipeline_output["stats"]["stats_tsv"],
+        #     "rqcfilter_log": pipeline_output["rqcfilter"]["run_log"],
+        #     "spades_log": pipeline_output["spades"]["run_log"],
+        #     "spades_params": pipeline_output["spades"]["params_log"]
+        # }
+        # if pipeline_output["spades"].get("warnings_log"):
+        #     stats_files["spades_warnings"] = pipeline_output["spades"]["warnings_log"]
+        # for f in ["pre_filter", "filtered", "corrected"]:
+        #     if f in pipeline_output["reads_info"]:
+        #         stats_files[f + "_reads"] = pipeline_output["reads_info"][f]["output_file"]
+        # return report_util.make_report(stats_files, pipeline_output["reads_info"],
+        #                                workspace_name, stored_objects)

--- a/lib/jgi_mg_assembly/runner/pipeline.py
+++ b/lib/jgi_mg_assembly/runner/pipeline.py
@@ -149,11 +149,9 @@ class Pipeline(object):
         bbmap_output = bbmap_runner.run(rqc_output["filtered_fastq_file"], spades_output["contigs_file"])
 
         return_dict = {
-            "reads_info": {
-                "pre_filter": reads_info_initial,
-                "filtered": reads_info_filtered,
-                "corrected": reads_info_corrected
-            },
+            "reads_info_prefiltered": reads_info_initial,
+            "reads_info_filtered": reads_info_filtered,
+            "reads_info_corrected": reads_info_corrected,
             "rqcfilter": rqc_output,
             "bfc": bfc_output,
             "seqtk": seqtk_output,
@@ -190,15 +188,17 @@ class Pipeline(object):
         Builds and uploads a report. This contains both an HTML report for display as well
         as a list of report files with various outputs from the pipeline.
 
-        pipeline_output - dict, expects the following keys:
-        * bbmap_stats - the bbmap stats file
-        * bbmap_coverage - the covstats.txt file
-        * assembly_stats - the AGP assembly stats file
-        * assembly_tsv - the AGP assembly stats tsv file (different contents)
-        * rqcfilter_log - the output log from rqcfilter
-        * reads_info - a dictionary containing info about the reads at each step (initial, filtered, and corrected)
-        *   - should have keys: pre_filter, filtered, corrected,
-        *   - contents are the results of readlength() for each case
+        pipeline_output - dict, expects the following keys, from each of the different steps
+        * reads_info_prefiltered
+        * reads_info_filtered
+        * reads_info_corrected
+        * rqcfilter
+        * bfc
+        * seqtk
+        * spades
+        * agp
+        * stats
+        * bbmap
 
         output_objects - dict, expects to see
         * assembly_upa - the UPA for the new assembly object

--- a/pipeline.cfg
+++ b/pipeline.cfg
@@ -1,0 +1,5 @@
+[versions]
+BBtools = 38.19
+SPAdes = 3.12.0
+SeqTK = 1.2-r101
+BFC = r181


### PR DESCRIPTION
**Note**: this depends on the previous PR #29, so that should be merged first.

Rewrote how the output report download works.
1. Refactored the internal objects to be a little more consistent. The data structure now just has a key for each step, and most of the same values.
2. Added a subdirectory for each step that produces files that are part of the report - logs, or coverage stats, etc. So, nothing from BFC or SeqTK.
3. Added a "pipeline_info.json" file. This is a list of all steps that are used, the actual command that's run in the shell, and the version maintained by the module.
4. To fill out 3., there's now a versions.cfg file in the repo root. Not sure what's the best answer for RQCFilter - maybe the BBTools module needs a "version" local function? And to return the formatted command in its output structure? Will do so.