### PR TITLE
Change text and error output

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.5.4
+    0.5.5
 
 owners:
     [wjriehl]

--- a/lib/jgi_mg_assembly/pipeline_steps/rqcfilter.py
+++ b/lib/jgi_mg_assembly/pipeline_steps/rqcfilter.py
@@ -78,7 +78,7 @@ class RQCFilterRunner(Step):
         "filtered_fastq_file" is the unchanged fastq file, other than gzipping it.
         run_log is just an empty (but existing!) file.
         """
-        print("NOT running RQCFilter, just dummying up some results.")
+        print("NOT running RQCFilter, just putting together some results.")
         # make the dummy output dir
         outdir = os.path.join(self.scratch_dir, "dummy_rqcfilter_output_{}".format(int(time() * 1000)))
         mkdir(outdir)

--- a/lib/jgi_mg_assembly/runner/pipeline.py
+++ b/lib/jgi_mg_assembly/runner/pipeline.py
@@ -111,11 +111,11 @@ class Pipeline(object):
             errors.append("Filtered reads are not created when skipping the RQCFilter step, so do not set filtered_reads_name")
         if params.get("alignment_name"):
             if not params.get("skip_rqcfilter") and not params.get("filtered_reads_name"):
-                errors.append("When uploading an alignment, and not skipping the RQCFilter step, the filtered reads must be uploaded as well and require a name.")
+                errors.append("When uploading an alignment, and performing the RQCFilter step, the filtered reads must also be saved, and require a name.")
         if len(errors):
             for error in errors:
                 print(error)
-            raise ValueError("Errors found in app parameters! See above for details.")
+            raise ValueError("; ".join(errors))
 
     def _run_assembly_pipeline(self, files, options):
         """

--- a/ui/narrative/methods/run_mg_assembly_pipeline/display.yaml
+++ b/ui/narrative/methods/run_mg_assembly_pipeline/display.yaml
@@ -34,7 +34,7 @@ parameters :
             The Paired-End Reads to assemble
     output_assembly_name :
         ui-name : |
-            Assembly Output
+            Assembly Output (required)
         short-hint : |
             The name of the assembled output
     skip_rqcfilter:
@@ -44,17 +44,17 @@ parameters :
             If selected, skips running the RQCFilter step of the pipeline, which filters out adapters, low quality reads, etc. See the catalog page for details.
     cleaned_reads_name:
         ui-name: |
-            Cleaned Reads Output (optional)
+            Cleaned Reads Output (optional, set a name to save)
         short-hint: |
             If set, stores the processed reads as a new object. These will have been cleaned by processing with RQCFilter, BFC, and SeqTK.
     filtered_reads_name :
         ui-name: |
-            Filtered Reads Output (optional - must be set if not skipping RQCFilter, and saving the alignment)
+            Filtered Reads Output (must be set if running RQCFilter and saving the alignment.)
         short-hint: |
             If set, this will save the RQCFiltered reads as a new Reads object. This MUST be set if the final alignment is to be saved and RQCFilter is not skipped.
     output_alignment_name :
         ui-name: |
-            Assembly Alignment Name (optional)
+            Assembly Alignment Name (optional, set a name to save the alignment)
         short-hint: |
             If set, this will save the BAM alignment between the filtered reads and the final assembly. Note that if not skipping RQCFilter, then the Filtered Reads must be saved as well.
 


### PR DESCRIPTION
Parameter errors should now appear in error output, not just something saying to look at the logs.